### PR TITLE
Add club tag management & fix deleted user calling the tag api

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -105,7 +105,7 @@ func (app *App) setRoutes() {
 	app.Delete("/clubs/{name}", app.Handle(handler.DeleteClub, true)) // Done
 	app.Post("/clubs/{clubname}/manages/{username}", app.Handle(handler.AddManager, true)) // Adding managers/maintainers to club
 	app.Delete("/clubs/{clubname}/manages/{username}", app.Handle(handler.RemoveManager, true)) // Removing managers/maintainers
-	//app.Post("/clubs/{username}/tags", app.Handle(handler.)) (Adding tags for clubs)
+	app.Post("/clubs/{clubname}/tags", app.Handle(handler.UpdateClubTags, true)) // (Adding tags for clubs)
 
 	app.Get("/clubs", app.Handle(handler.GetClubs, false))
 	app.Get("/clubs/tags/{tag}", app.Handle(handler.GetClubsTag, false))

--- a/app/handler/common.go
+++ b/app/handler/common.go
@@ -102,7 +102,7 @@ func kf(token *jwt.Token) (interface{}, error) {
 Returning true if the record already exists in the table, false otherwise.
 */
 //You can put a check on Record Exists on the deleted column as long as it's null it'll exist then
-// WHen soft deleted, the record won't exist anymore
+// When soft deleted, the record won't exist anymore
 func SingleRecordExists(db *gorm.DB, tableName string, column string, val string, t interface{}) bool {
 	result := db.Table(tableName).Where(column+"= ?", val).First(t)
 	return result.Error == nil

--- a/app/handler/tags.go
+++ b/app/handler/tags.go
@@ -108,6 +108,21 @@ func GetTags(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
 	WriteData(GetJSON(status), http.StatusOK, w)
 }
 
+/*
+Extract all tags from payload and returns them as an array of model.Tag
+ */
+func extractTags(db *gorm.DB, r *http.Request) []model.Tag {
+	var chooses []model.Tag
+	for _, name := range getTagInfo(r) {
+		tag := model.NewTag()
+		if SingleRecordExists(db, model.TagTable, model.NameColumn, name, tag) {
+			tag.Name = name
+			chooses = append(chooses, *tag)
+		}
+	}
+	return chooses
+}
+
 func DeleteTag(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
 	status := model.NewStatus()
 	if isAdmin(db, r) {

--- a/app/model/club.go
+++ b/app/model/club.go
@@ -17,19 +17,19 @@ type Club struct {
 }
 
 func NewClub() *Club {
-	return &Club{}
+	return &Club{Sets: []Tag{}}
 }
 
 const (
-	SetsColum        = "Sets"
+	SetsColumn       = "Sets"
 	TagsColumn       = "tags"
 	HostsColumn      = "Hosts"
 	SizeColumn       = "size"
 	BioColumn        = "bio"
 	HelpNeededColumn = "help_needed"
+
 	ClubTable        = "club"
 	NameColumn       = "name"
-	OpAdd = "ADD"
-	OpRemove = "REMOVE"
-
+	OpAdd            = "ADD"
+	OpRemove         = "REMOVE"
 )

--- a/app/model/credentials.go
+++ b/app/model/credentials.go
@@ -15,6 +15,7 @@ func NewCredentials() *Credentials {
 }
 
 const (
+
 	UsernameColumn  = "username"
 	EmailColumn     = "email"
 	PasswordColumn  = "password"


### PR DESCRIPTION
- Club owners and managers can update their tags
- Fixed multiple security flaws with JWT and user deletion when updating tags (i.e. If users were hard deleted and they had a hold of their JWT, they could update their tags => This creates side effects such as a blank user being created)