### PR TITLE
Add user and club approval toggle

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -96,8 +96,8 @@ func (app *App) setRoutes() {
 	app.Get("/users/{username}/attends", app.Handle(handler.GetUserEventsAttend, true)) // Done
 	app.Post("/events/{eid:[0-9]+}/attend", app.Handle(handler.AddUserAttendsEvent, true)) // Done
 	app.Post("/events/{eid:[0-9]+}/unattend", app.Handle(handler.RemoveUserAttendsEvent, true)) // Done
-	app.Post("/resetpassword/{username}", app.Handle(handler.RequestResetUserPassword, false))
-	app.Post("/resetpassword/{username}/{token}", app.Handle(handler.ResetUserPassword, false))
+	app.Post("/resetpassword/{username}", app.Handle(handler.RequestResetUserPassword, false)) // Done
+	app.Post("/resetpassword/{username}/{token}", app.Handle(handler.ResetUserPassword, false)) // Done
 	app.Post("/users/{username}", app.Handle(handler.UpdateUserPassword, true))
 	// Potential code merger on /clubs/{name} and /users/{username}
 
@@ -108,9 +108,9 @@ func (app *App) setRoutes() {
 	app.Post("/toggle/tags/{tagName}", app.Handle(handler.ToggleTag, true)) // Done
 
 	// Club routes
-	app.Post("/clubs", app.Handle(handler.CreateClub, true))           // Done
+	app.Post("/clubs", app.Handle(handler.CreateClub, true))              // Done
 	app.Post("/clubs/{cid:[0-9]+}", app.Handle(handler.UpdateClub, true)) // Done
-	app.Get("/clubs/{cid:[0-9]+}", app.Handle(handler.GetClub, false)) // Done
+	app.Get("/clubs/{cid:[0-9]+}", app.Handle(handler.GetClub, false))    // Done
 
 	//app.Delete("/clubs/{name}", app.Handle(handler.DeleteClub, true)) // Partially Done (The owner can delete the club and all associations will be removed?) (Clubs can't be deleted, only deactivated)
 	app.Post("/clubs/{cid:[0-9]+}/manages/{username}", app.Handle(handler.AddManager, true))      // Done (Adding managers/maintainers to club)
@@ -121,10 +121,9 @@ func (app *App) setRoutes() {
 
 
 
-	app.Get("/events", app.Handle(handler.GetAllEvents, false)) // Done
-	app.Get("/events/{eid:[0-9]+}", app.Handle(handler.GetEvent, false)) // Done
+	app.Get("/events", app.Handle(handler.GetAllEvents, false))                     // Done
+	app.Get("/events/{eid:[0-9]+}", app.Handle(handler.GetEvent, false))            // Done
 	app.Get("/clubs/{cid:[0-9]+}/events", app.Handle(handler.GetClubEvents, false)) // Done
-
 	app.Post("/clubs/{cid:[0-9]+}/events", app.Handle(handler.CreateClubEvent, true)) // Done
 
 	app.Post("/clubs/{cid:[0-9]+}/events/{eid:[0-9]+}", app.Handle(handler.UpdateClubEvent, true)) // In-Progress

--- a/app/handler/events.go
+++ b/app/handler/events.go
@@ -3,40 +3,41 @@ package handler
 import (
 	"fmt"
 	"github.com/2-of-clubs/2ofclubs-server/app/model"
+	"github.com/2-of-clubs/2ofclubs-server/app/status"
 	"github.com/go-playground/validator"
 	"gorm.io/gorm"
 	"net/http"
 )
 
 func GetAllEvents(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
-	status := model.NewStatus()
+	s := status.New()
 	events := []model.Event{}
 	result := db.Find(&events)
 	if result.Error != nil {
-		status.Message = model.GetAllEventsFailure
+		s.Message = status.GetAllEventsFailure
 	} else {
 		allEvents := make(map[string][]model.Event)
 		allEvents["Events"] = events
-		status.Message = model.AllEventsFound
-		status.Code = model.SuccessCode
-		status.Data = allEvents
+		s.Message = status.AllEventsFound
+		s.Code = status.SuccessCode
+		s.Data = allEvents
 	}
-	WriteData(GetJSON(status), http.StatusOK, w)
+	WriteData(GetJSON(s), http.StatusOK, w)
 }
 
 func GetEvent(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
 	eventID := getVar(r, model.EventIDVar)
 	event := model.NewEvent()
-	status := model.NewStatus()
+	s := status.New()
 	eventExists := SingleRecordExists(db, model.EventTable, model.IDColumn, eventID, event)
 	if eventExists {
-		status.Code = model.SuccessCode
-		status.Message = model.EventFound
-		status.Data = event
+		s.Code = status.SuccessCode
+		s.Message = status.EventFound
+		s.Data = event
 	} else {
-		status.Message = model.EventNotFound
+		s.Message = status.EventNotFound
 	}
-	WriteData(GetJSON(status), http.StatusOK, w)
+	WriteData(GetJSON(s), http.StatusOK, w)
 
 }
 
@@ -49,25 +50,25 @@ func DeleteClubEvent(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
 	club := model.NewClub()
 	event := model.NewEvent()
 	user := model.NewUser()
-	status := model.NewStatus()
-	clubExists := SingleRecordExists(db, model.ClubTable, model.IDColumn, clubID, club)
+	s := status.New()
+	clubExists := IsSingleRecordActive(db, model.ClubTable, model.IDColumn, clubID, club)
 	eventExists := SingleRecordExists(db, model.EventTable, model.IDColumn, eid, event)
-	userExists := SingleRecordExists(db, model.UserTable, model.UsernameColumn, uname, user)
+	userExists := IsSingleRecordActive(db, model.UserTable, model.UsernameColumn, uname, user)
 	if userExists && eventExists && clubExists && isManager(db, user, club) {
-		status.Code = model.SuccessCode
-		status.Message = model.EventDeleted
+		s.Code = status.SuccessCode
+		s.Message = status.EventDeleted
 		db.Delete(event)
 	} else if !userExists {
-		status.Message = model.UserNotFound
+		s.Message = status.UserNotFound
 	} else if !clubExists {
-		status.Message = model.ClubNotFound
+		s.Message = status.ClubNotFound
 	} else if !eventExists {
-		status.Message = model.EventNotFound
+		s.Message = status.EventNotFound
 	} else {
 		statusCode = http.StatusForbidden
-		status.Message = http.StatusText(http.StatusForbidden)
+		s.Message = http.StatusText(http.StatusForbidden)
 	}
-	WriteData(GetJSON(status), statusCode, w)
+	WriteData(GetJSON(s), statusCode, w)
 }
 
 /*
@@ -90,9 +91,9 @@ func manageClubEvent(db *gorm.DB, w http.ResponseWriter, r *http.Request, operat
 	user := model.NewUser()
 	event := model.NewEvent()
 	validate := validator.New()
-	status := model.NewStatus()
-	clubExists := SingleRecordExists(db, model.ClubTable, model.IDColumn, clubID, club)
-	userExists := SingleRecordExists(db, model.UserTable, model.UsernameColumn, uname, user)
+	s := status.New()
+	clubExists := IsSingleRecordActive(db, model.ClubTable, model.IDColumn, clubID, club)
+	userExists := IsSingleRecordActive(db, model.UserTable, model.UsernameColumn, uname, user)
 	switch operation {
 	case model.OpCreate:
 		if userExists && isManager(db, user, club) && clubExists {
@@ -100,11 +101,11 @@ func manageClubEvent(db *gorm.DB, w http.ResponseWriter, r *http.Request, operat
 			err := validate.Struct(event)
 			if err == nil {
 				db.Model(club).Association(model.HostsColumn).Append(event)
-				status.Code = model.SuccessCode
-				status.Message = model.CreateEventSuccess
+				s.Code = status.SuccessCode
+				s.Message = status.CreateEventSuccess
 			} else {
-				status.Message = model.CreateEventFailure
-				status.Data = model.NewEventRequirement()
+				s.Message = status.CreateEventFailure
+				s.Data = model.NewEventRequirement()
 			}
 		}
 	case model.OpUpdate:
@@ -116,23 +117,23 @@ func manageClubEvent(db *gorm.DB, w http.ResponseWriter, r *http.Request, operat
 			err := validate.Struct(updatedEvent)
 			if err == nil {
 				db.Model(event).Updates(updatedEvent)
-				status.Code = model.SuccessCode
-				status.Message = model.UpdateEventSuccess
+				s.Code = status.SuccessCode
+				s.Message = status.UpdateEventSuccess
 			} else {
-				status.Message = model.UpdateEventFailure
-				status.Data = model.NewEventRequirement()
+				s.Message = status.UpdateEventFailure
+				s.Data = model.NewEventRequirement()
 			}
 		} else if !eventExists {
-			status.Message = model.EventNotFound
+			s.Message = status.EventNotFound
 		}
 	}
 	if !clubExists {
-		status.Message = model.ClubNotFound
+		s.Message = status.ClubNotFound
 	} else if !isManager(db, user, club) {
 		httpStatusCode = http.StatusForbidden
-		status.Message = http.StatusText(httpStatusCode)
+		s.Message = http.StatusText(httpStatusCode)
 	}
-	WriteData(GetJSON(status), httpStatusCode, w)
+	WriteData(GetJSON(s), httpStatusCode, w)
 }
 
 func RemoveUserAttendsEvent(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
@@ -144,27 +145,27 @@ func AddUserAttendsEvent(db *gorm.DB, w http.ResponseWriter, r *http.Request) {
 }
 
 func manageUserAttends(db *gorm.DB, w http.ResponseWriter, r *http.Request, operation string) {
-	status := model.NewStatus()
+	s := status.New()
 	eventID := getVar(r, model.EventIDVar)
 	claims := GetTokenClaims(r)
 	uname := fmt.Sprintf("%v", claims["sub"])
 	event := model.NewEvent()
 	user := model.NewUser()
 	eventExists := SingleRecordExists(db, model.EventTable, model.IDColumn, eventID, event)
-	userExists := SingleRecordExists(db, model.UserTable, model.UsernameColumn, uname, user)
+	userExists := IsSingleRecordActive(db, model.UserTable, model.UsernameColumn, uname, user)
 	if eventExists && userExists {
 		switch operation {
 		case model.OpAdd:
 			db.Model(user).Association(model.AttendsColumn).Append(event)
-			status.Code = model.SuccessCode
-			status.Message = model.EventFound
+			s.Code = status.SuccessCode
+			s.Message = status.EventFound
 		case model.OpRemove:
 			db.Model(user).Association(model.AttendsColumn).Delete(event)
-			status.Code = model.SuccessCode
-			status.Message = model.EventFound
+			s.Code = status.SuccessCode
+			s.Message = status.EventFound
 		}
 	} else {
-		status.Message = model.EventNotFound
+		s.Message = status.EventNotFound
 	}
-	WriteData(GetJSON(status), http.StatusOK, w)
+	WriteData(GetJSON(s), http.StatusOK, w)
 }

--- a/app/logger/logger.go
+++ b/app/logger/logger.go
@@ -11,7 +11,7 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 			w.Header().Add("Content-Type", "application/json")
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Request-Methods", "POST, GET, OPTIONS, PUT, DELETE")
-			w.Header().Set("Access-Control-Allow-Headers", "Accept, Accept-Language, Content-Type, YourOwnHeader")
+			w.Header().Set("Access-Control-Allow-Headers", "Accept, Accept-Language, Content-Type")
 
 		}
 		log.Println(r.RequestURI)

--- a/app/model/base.go
+++ b/app/model/base.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Base struct {
-	ID        uint           `gorm:"primarykey"`
-	CreatedAt time.Time      `json:"-"`
-	UpdatedAt time.Time      `json:"-"`
-	DeletedAt gorm.DeletedAt `json:"-" gorm:"index"`
+	ID        uint           `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time      `json:"-" json:"createdAt"`
+	UpdatedAt time.Time      `json:"-" json:"updatedAt"`
+	DeletedAt gorm.DeletedAt `json:"-" gorm:"index" json:"deletedAt"`
 }

--- a/app/model/club.go
+++ b/app/model/club.go
@@ -13,13 +13,13 @@ type Club struct {
 }
 
 type ClubDisplay struct {
-	ID    uint
-	Name  string
-	Email string
-	Bio   string
-	Size  int
-	Tags  []string
-	Hosts []Event
+	ID    uint     `json:"id"`
+	Name  string   `json:"name"`
+	Email string   `json:"email"`
+	Bio   string   `json:"bio"`
+	Size  int      `json:"size"`
+	Tags  []string `json:"tags"`
+	Hosts []Event  `json:"hosts"`
 }
 
 func (c *Club) Display() *ClubDisplay {
@@ -47,7 +47,7 @@ const (
 	SizeColumn        = "size"
 	BioColumn         = "bio"
 	HelpNeededColumn  = "help_needed"
-	ClubTable  = "club"
-	NameColumn = "name"
-
+	ClubTable         = "club"
+	NameColumn        = "name"
+	ActiveColumn      = "active"
 )

--- a/app/model/credentials.go
+++ b/app/model/credentials.go
@@ -1,9 +1,9 @@
 package model
 
 type Credentials struct {
-	Username string `gorm:"UNIQUE" validate:"alpha,min=2,max=15,required"`
-	Email    string `gorm:"UNIQUE" validate:"required,email"`
-	Password string `validate:"required,min=3,max=45"`
+	Username string `gorm:"UNIQUE" validate:"alpha,min=2,max=15,required" json:"username"`
+	Email    string `gorm:"UNIQUE" validate:"required,email" json:"email"`
+	Password string `validate:"required,min=3,max=45" json:"password"`
 	// Max 45 due to 50 length limitation of bcrypt
 }
 

--- a/app/model/event.go
+++ b/app/model/event.go
@@ -1,12 +1,14 @@
 package model
 
+import "github.com/2-of-clubs/2ofclubs-server/app/status"
+
 type Event struct {
 	Base
-	Name string `validate:"required,min=1,max=50"`
+	Name string `validate:"required,min=1,max=50" json:"name"`
 	//DateTime    time.Time  `validate:"required,gtetoday,datetime"`
-	Description string  `validate:"required,max=300"`
-	Location    string  `validate:"required,max=100"`
-	Fee         float64 `validate:"required,gte=0"`
+	Description string  `validate:"required,max=300" json:"description"`
+	Location    string  `validate:"required,max=100" json:"location"`
+	Fee         float64 `validate:"required,gte=0" json:"fee"`
 }
 
 func NewEvent() *Event {
@@ -23,11 +25,11 @@ type EventRequirement struct {
 
 func NewEventRequirement() *EventRequirement {
 	return &EventRequirement{
-		Admin:       ManagerOwnerRequired,
-		Name:        EventNameConstraint,
-		Description: EventDescriptionConstraint,
-		Location:    EventLocationConstraint,
-		Fee:         EventFeeConstraint,
+		Admin:       status.ManagerOwnerRequired,
+		Name:        status.EventNameConstraint,
+		Description: status.EventDescriptionConstraint,
+		Location:    status.EventLocationConstraint,
+		Fee:         status.EventFeeConstraint,
 	}
 }
 

--- a/app/model/tag.go
+++ b/app/model/tag.go
@@ -20,5 +20,5 @@ func NewTag() *Tag {
 const (
 	TagNameVar     = "tagName"
 	TagTable       = "tag"
-	IsActiveColumn = "is_active"
+	IsActiveColumn = "IsActive"
 )

--- a/app/model/user.go
+++ b/app/model/user.go
@@ -11,15 +11,15 @@ type User struct {
 }
 
 type UserDisplay struct {
-	Email   string
-	Manages []*ManagesDisplay
-	Tags    []string
-	Attends []Event
+	Email   string `json:"email"`
+	Manages []*ManagesDisplay `json:"manages"`
+	Tags    []string `json: "tags"`
+	Attends []Event `json: "attends"`
 }
 
 type ManagesDisplay struct {
 	*ClubDisplay
-	IsOwner bool
+	IsOwner bool `json:"isOwner"`
 }
 
 func (u *User) Display() *UserDisplay {

--- a/app/status/status.go
+++ b/app/status/status.go
@@ -1,11 +1,17 @@
-package model
+package status
 
 const (
+	// Status Code
+	FailureCode = -1
+	SuccessCode = 1
+
+	// Manager
 	ManagerRemoveFailure   = "Unable to remove manager"
 	ManagerAdditionFailure = "Unable to add manager"
 	ManagerRemoveSuccess   = "Successfully removed manager"
 	ManagerAdditionSuccess = "Successfully added manager"
 
+	// Tags
 	TagUpdateError = "Error Updating Tag"
 	TagUpdated     = "Tag Updated"
 	TagCreated     = "Successfully created tag"
@@ -16,6 +22,23 @@ const (
 	TagsGetFailure = "Unable to get tags"
 	TagNotFound    = "Tag doesn't exist"
 
+	// Authentication
+	SignupSuccess    = "Signup Successful"
+	SignupFailure    = "Unable to Sign Up User"
+	LoginSuccess     = "Successfully logged in"
+	LoginFailure     = "Username or Password is Incorrect"
+	UsernameExists   = "Username already exists"
+	UsernameAlphaNum = "Username must start with a letter and can only contain the following characters: a-zA-Z0-9_ and must be 50 characters or less"
+	ValidEmail       = "Must be a valid email"
+	EmailExists      = "Email already exists"
+
+	// Password Update/Reset
+	PasswordUpdateSuccess = "Successfully updated password"
+	PasswordUpdateFailure = "Unable to update password"
+	EmailSendFailure      = "Unable to send email"
+	EmailSendSuccess      = "Successfully sent email if user exists"
+
+	// User & Club
 	UserUpdated         = "Updated User"
 	UserFound           = "User Found"
 	UserNotFound        = "User Not Found"
@@ -28,32 +51,22 @@ const (
 	ClubUpdateSuccess   = "Successfully updated club"
 	ClubUpdateFailure   = "Unable to update club"
 
-	UsernameExists   = "Username already exists"
-	UsernameAlphaNum = "Username must start with a letter and can only contain the following characters: a-zA-Z0-9_ and must be 50 characters or less"
-	ValidEmail       = "Must be a valid email"
-	EmailExists      = "Email already exists"
-
+	// Admin
 	GetNonToggledUsersFailure = "Unable to retrieve non toggled users"
 	GetNonToggledUsersSuccess = "Retrieved all non toggled users"
+	ManagerOwnerRequired      = "You must be a manager or owner of the club"
+	AdminRequired             = "Please contact an administrator."
+	InvalidFile               = "Invalid File: A .txt file is required"
+	UnableToReadFile          = "Unable to read file"
+	FileNotFound              = "File doesn't exist"
+	UserNotApproved           = "Sorry, your account has not been approved yet"
+	ClubNotActive             = "Sorry, this club isn't active yet. Please wait until an administrator activates the club."
 
-	ManagerOwnerRequired = "You must be a manager or owner of the club"
-	AdminRequired        = "Please contact an administrator."
-	InvalidFile          = "Invalid File: A .txt file is required"
-	UnableToReadFile     = "Unable to read file"
-	FileNotFound         = "File doesn't exist"
-
-	UserNotApproved       = "Sorry, your account has not been approved yet"
-	ClubNotActive         = "Sorry, this club isn't active yet. Please wait until an administrator activates the club."
-	LoginSuccess          = "Successfully logged in"
-	LoginFailure          = "Username or Password is Incorrect"
-	PasswordUpdateSuccess = "Successfully updated password"
-	PasswordUpdateFailure = "Unable to update password"
-
-	CreateEventSuccess = "Successfully created event"
-	CreateEventFailure = "Unable to create event"
-	UpdateEventSuccess = "Successfully updated event"
-	UpdateEventFailure = "Unable to update event"
-
+	// Events
+	CreateEventSuccess         = "Successfully created event"
+	CreateEventFailure         = "Unable to create event"
+	UpdateEventSuccess         = "Successfully updated event"
+	UpdateEventFailure         = "Unable to update event"
 	EventNameConstraint        = "Event name must be at least 1 character and a maximum of 50 characters"
 	EventDescriptionConstraint = "Event description must be a maximum of 300 characters or less"
 	EventLocationConstraint    = "Event location must be a maximum of 100 characters or less"
@@ -64,30 +77,26 @@ const (
 	GetAllEventsFailure        = "Unable to get all events"
 	AllEventsFound             = "All Events Found"
 
+	// Hashing
 	HashErr     = "hashing Error"
 	ErrTokenGen = "token generation error"
 
-	EmailSendFailure = "Unable to send email"
-	EmailSendSuccess = "Successfully sent email if user exists"
-
 	ErrGeneric  = "an error occurred"
-	FailureCode = -1
-	SuccessCode = 1
 )
 
 type T struct{}
 
 type Status struct {
-	Code    int
-	Message string
-	Data    interface{}
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data"`
 }
 
 type CredentialStatus struct {
-	Username string
-	Email    string
+	Username string `json:"username"`
+	Email    string `json:"email"`
 }
 
-func NewStatus() *Status {
+func New() *Status {
 	return &Status{Code: FailureCode, Message: "", Data: T{}}
 }


### PR DESCRIPTION
- [x] When a user or a club is created, they are inactive by default
- [x] Admins can toggle users and clubs (actives/deactivates)
- [x] Users/Clubs that are inactive won't show up in any API query

Minor side edits
- Refactored and organized some functions (improves clarity)
- Some HTTP Methods display the correct response codes
- JSON payloads
