### PR TITLE
Add user leave club and owner promotes new club owner functionality

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -130,23 +130,24 @@ func (app *App) setRoutes() {
 	app.Post("/toggle/tags/{tagName}", app.Handle(handler.ToggleTag, true)) // Done
 
 	// Club routes
-	app.Post("/clubs", app.Handle(handler.CreateClub, true))                                      // Done
-	app.Post("/clubs/{cid:[0-9]+}", app.Handle(handler.UpdateClub, true))                         // Done
-	app.Get("/clubs/{cid:[0-9]+}", app.Handle(handler.GetClub, false))                            // Done
-	app.Get("/clubs/{cid:[0-9]+}/manages", app.Handle(handler.GetClubManagers, true))             // Done
-	app.Post("/clubs/{cid:[0-9]+}/manages/{username}", app.Handle(handler.AddManager, true))      // Done (Adding managers/maintainers to club)
-	app.Delete("/clubs/{cid:[0-9]+}/manages/{username}", app.Handle(handler.RemoveManager, true)) // Partially done (Removing managers/maintainers) (If the current owner wants to leave, then they must appoint a new person)
-	app.Post("/clubs/{cid:[0-9]+}/tags", app.Handle(handler.UpdateClubTags, true))                // Done
-	app.Get("/clubs", app.Handle(handler.GetClubs, false))                                        // In-Progress
-
-	app.Get("/events", app.Handle(handler.GetAllEvents, false))                       // Done
-	app.Get("/events/{eid:[0-9]+}", app.Handle(handler.GetEvent, false))              // Done
-	app.Get("/clubs/{cid:[0-9]+}/events", app.Handle(handler.GetClubEvents, false))   // Done
-	app.Post("/clubs/{cid:[0-9]+}/events", app.Handle(handler.CreateClubEvent, true)) // Done
-
+	app.Post("/clubs", app.Handle(handler.CreateClub, true))                                         // Done
+	app.Post("/clubs/{cid:[0-9]+}", app.Handle(handler.UpdateClub, true))                            // Done
+	app.Get("/clubs/{cid:[0-9]+}", app.Handle(handler.GetClub, false))                               // Done
+	app.Get("/clubs/{cid:[0-9]+}/manages", app.Handle(handler.GetClubManagers, true))                // Done
+	app.Post("/clubs/{cid:[0-9]+}/manages/{username}", app.Handle(handler.AddManager, true))         // Done
+	app.Delete("/clubs/{cid:[0-9]+}/manages/{username}", app.Handle(handler.RemoveManager, true))    // Done
+	app.Post("/clubs/{cid:[0-9]+}/leave", app.Handle(handler.LeaveClub, true))                       // Done
+	app.Post("/clubs/{cid:[0-9]+}/promote/{username}", app.Handle(handler.PromoteOwner, true))       // Done
+	app.Post("/clubs/{cid:[0-9]+}/tags", app.Handle(handler.UpdateClubTags, true))                   // Done
+	app.Get("/clubs", app.Handle(handler.GetClubs, false))                                           // In-Progress
+	app.Get("/clubs/{cid:[0-9]+}/events", app.Handle(handler.GetClubEvents, false))                  // Done
+	app.Post("/clubs/{cid:[0-9]+}/events", app.Handle(handler.CreateClubEvent, true))                // Done
 	app.Post("/clubs/{cid:[0-9]+}/events/{eid:[0-9]+}", app.Handle(handler.UpdateClubEvent, true))   // Done
 	app.Delete("/clubs/{cid:[0-9]+}/events/{eid:[0-9]+}", app.Handle(handler.DeleteClubEvent, true)) // Done
 
+	// Event Routes
+	app.Get("/events", app.Handle(handler.GetAllEvents, false))          // Done
+	app.Get("/events/{eid:[0-9]+}", app.Handle(handler.GetEvent, false)) // Done
 	// 404 Route
 	app.router.NotFoundHandler = notFound() // Done
 }

--- a/app/status/status.go
+++ b/app/status/status.go
@@ -55,6 +55,12 @@ const (
 
 // User & Club status messages
 const (
+	ClubPromoteSuccess         = "successfully promoted new owner"
+	ClubPromoteSelfFailure     = "you can't promote yourself to an owner if you're already an owner"
+	ClubPromoteOwnerFailure    = "you must be the owner of the club in order to promote a new owner"
+	ClubPromoteNeedManager     = "the user you're trying to promote must be a club manager"
+	LeaveClubFailure           = "sorry, only managers can leave the club. If you wish to do so, please promote another owner for this club"
+	LeaveClubSuccess           = "successfully left club"
 	ClubAlreadyActive          = "sorry, this club is already active"
 	GetClubManagerSuccess      = "retrieved all club managers"
 	ToggleUserSuccess          = "toggled user"
@@ -102,6 +108,7 @@ const (
 
 // Photo upload status messages
 const (
+	InvalidPhotoSize   = "invalid file: A photo of 10 MB or less is required"
 	InvalidPhotoFormat = "invalid file: A .jpg or .png file of 10 MB or less is required"
 	FileUploadSuccess  = "successfully uploaded file"
 	ClubPhotoNotFound  = "unable to find a photo for the club"


### PR DESCRIPTION
- [x] Current club owners can demote themselves to a manager and promote a new club owner
- [x] Any club managers can leave a club (i.e. no longer associate with the club) (Note: Owners need to demote themselves to a manager before they can leave the club)
